### PR TITLE
Add versioning option to S3 bucket module

### DIFF
--- a/modules/s3_buckets/s3.tf
+++ b/modules/s3_buckets/s3.tf
@@ -1,6 +1,13 @@
 ## tf s3 resources
 
 resource "aws_s3_bucket" "bucket" {
-    bucket_prefix = "${var.bucket_name_prefix}-${var.environment}-${var.aws_region}"
-    force_destroy = true
+  bucket_prefix = "${var.bucket_name_prefix}-${var.environment}-${var.aws_region}"
+  force_destroy = true
+
+  dynamic "versioning" {
+    for_each = var.enable_versioning ? [1] : []
+    content {
+      enabled = true
+    }
+  }
 }

--- a/modules/s3_buckets/vars.tf
+++ b/modules/s3_buckets/vars.tf
@@ -11,3 +11,8 @@ variable "aws_region" {
 variable "bucket_name_prefix" {
   type = string
 }
+
+variable "enable_versioning" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
## Summary
- support optional versioning in S3 bucket module

## Testing
- `terraform -v` *(fails: command not found)*
- `terragrunt -v` *(fails: command not found)*
- `terraform fmt -recursive -check` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ad0887ed88833393afc6887ccf55f7