### PR TITLE
Fix deployment path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This project provisions S3 bucket from Terraform module to sandbox accounts using Terragrunt.
 # Preconfiguration
 
-Before running any Terragrunt commands, ensure that the `project_name` is set in the `locals` block in `depployment/aws/_config/project.hcl`. This is required for proper configuration.
+Before running any Terragrunt commands, ensure that the `project_name` is set in the `locals` block in `deployment/aws/_config/project.hcl`. This is required for proper configuration.
 
 Add the following `locals` block to your Terragrunt configuration file:
 


### PR DESCRIPTION
## Summary
- correct path reference to `deployment/aws/_config/project.hcl` in README
- tidy trailing newline

## Testing
- `terraform --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a2622748333bc6eb3256bf1f426