### PR TITLE
Add optional S3 versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # iac-terragrunt-template
 This project provisions S3 bucket from Terraform module to sandbox accounts using Terragrunt.
+
+The S3 bucket module supports optional versioning via the `enable_versioning` variable, which defaults to `false`.
+
 # Preconfiguration
 
 Before running any Terragrunt commands, ensure that the `project_name` is set in the `locals` block in `deployment/aws/_config/project.hcl`. This is required for proper configuration.

--- a/modules/s3_buckets/outputs.tf
+++ b/modules/s3_buckets/outputs.tf
@@ -7,3 +7,8 @@ output "bucket_name" {
 output "aws_region" {
   value = var.aws_region
 }
+
+output "enable_versioning" {
+  value = var.enable_versioning
+}
+

--- a/modules/s3_buckets/s3.tf
+++ b/modules/s3_buckets/s3.tf
@@ -4,10 +4,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket_prefix = "${var.bucket_name_prefix}-${var.environment}-${var.aws_region}"
   force_destroy = true
 
-  dynamic "versioning" {
-    for_each = var.enable_versioning ? [1] : []
-    content {
-      enabled = true
-    }
+  versioning {
+    enabled = var.enable_versioning
   }
 }


### PR DESCRIPTION
## Summary
- enable S3 bucket versioning via new `enable_versioning` flag
- expose versioning choice as module output
- document versioning flag in README

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=modules/s3_buckets init -backend=false` (fails: Failed to query available provider packages: Forbidden)
- `terraform -chdir=modules/s3_buckets validate` (fails: Missing required provider)


------
https://chatgpt.com/codex/tasks/task_e_68ad0b190f008333801627c132e338c0