### PR TITLE
docs: fix overwritten comments

### DIFF
--- a/deployment/aws/_config/ec2/terragrunt.hcl
+++ b/deployment/aws/_config/ec2/terragrunt.hcl
@@ -12,7 +12,7 @@ dependency "vpc" {
 }
 
 inputs = {
-  # It will be overwrite
+  # It will be overwritten
   # name          = "single-instance"
   instance_type = "t2.micro"
   monitoring    = true

--- a/deployment/aws/_config/vpc/terragrunt.hcl
+++ b/deployment/aws/_config/vpc/terragrunt.hcl
@@ -4,7 +4,7 @@ terraform {
 
 inputs = {
   name = "TBD"
-  # It will be overwrite
+  # It will be overwritten
   # cidr = "10.0.0.0/16"
   # azs             = ["${local.region}a", "${local.region}b", "${local.region}c"]
   # private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
@@ -13,7 +13,7 @@ inputs = {
   enable_nat_gateway = false
   enable_vpn_gateway = false
 
-  # It will be overwrite
+  # It will be overwritten
   # tags = {
   #   IaC         = "true"
   #   Environment = "${local.environment}"

--- a/deployment/aws/modules/debuging/variables.tf
+++ b/deployment/aws/modules/debuging/variables.tf
@@ -22,7 +22,7 @@ variable "environment" {
 
 variable "extend_variable" {
   type = map(string)
-  # It can be overwrite
+  # It can be overwritten
   default = {}
 }
 


### PR DESCRIPTION
## Summary
- clarify overwrite wording in debugging module variables
- standardize comment phrasing in VPC and EC2 terragrunt configs

## Testing
- `terraform fmt -check -recursive`
- `terragrunt hcl format`

------
https://chatgpt.com/codex/tasks/task_e_68ad0b08fc7c8333a4ea108623a17215